### PR TITLE
add jq to base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV LSB_RELEASE jessie
 RUN apt-get update -qq \
     && apt-get install -qy \
         curl \
+        jq \
         apt-transport-https \
     && apt-get upgrade -qy \
     && apt-get -y autoremove \


### PR DESCRIPTION
so many things may want jq  even tho we use jsonpath in kube alot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/gcloud-kubectl-docker/2)
<!-- Reviewable:end -->
