### PR TITLE
adding make and ssh-keygen to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update -qq \
         curl \
         jq \
         apt-transport-https \
+        make \
+        openssh-client \
     && apt-get upgrade -qy \
     && apt-get -y autoremove \
     && apt-get -y clean \


### PR DESCRIPTION
Problem: Wanting to use this as the standard deployment image for circle 2.0 builds. To work with common make, both make and ssh-keygen are required.

Solution: Add to image